### PR TITLE
Refactoring,  solana-py only

### DIFF
--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -1,85 +1,130 @@
 "Detect  New Pools Created on Solana Raydium DEX"
 
 #TODO Add Buys ,Sells price and liquidity pool tracking management
+from pprint import pprint
 
 import asyncio
-import sys
+from typing import Iterator, List, AsyncIterator, Tuple
+from asyncstdlib import enumerate
 
-import websockets
-import json
+from solana.rpc.websocket_api import connect
+from solana.rpc.commitment import Finalized
 from solana.rpc.api import Client
+
 from solders.pubkey import Pubkey
+
+# Type hinting imports
+from solana.rpc.commitment import Commitment
+from solana.rpc.websocket_api import SolanaWsClientProtocol
+from solders.rpc.responses import RpcLogsResponse, SubscriptionResult, LogsNotification, GetTransactionResp
 from solders.signature import Signature
-import pandas as pd
-from tabulate import tabulate
+from solders.transaction_status import UiPartiallyDecodedInstruction, ParsedInstruction
 
-
-wallet_address = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
-seen_signatures = set()
-solana_client = Client("https://api.mainnet-beta.solana.com")
-
-def  getTokens(str_signature):
-    signature = Signature.from_string(str_signature)
-    transaction = solana_client.get_transaction(signature, encoding="jsonParsed",max_supported_transaction_version=0).value
-    instruction_list = transaction.transaction.transaction.message.instructions
-
-    for instructions in instruction_list:
-        if instructions.program_id == Pubkey.from_string(wallet_address):
-            print("============NEW POOL DETECTED====================")
-            Token0= instructions.accounts[8]
-            Token1= instructions.accounts[9]
-            # Your data
-            data = {'Token_Index': ['Token0', 'Token1'],
-                    'Account Public Key': [Token0, Token1]}
-
-            df = pd.DataFrame(data)
-            table = tabulate(df, headers='keys', tablefmt='fancy_grid')
-            print(table)
-             
-
-
-async def run():
-   uri = "wss://api.mainnet-beta.solana.com"
-   async with websockets.connect(uri) as websocket:
-       # Send subscription request
-       await websocket.send(json.dumps({
-           "jsonrpc": "2.0",
-           "id": 1,
-           "method": "logsSubscribe",
-           "params": [
-               {"mentions": [wallet_address]},
-               {"commitment": "finalized"}
-           ]
-       }))
-
-       first_resp = await websocket.recv()
-       response_dict = json.loads(first_resp)
-       if 'result' in response_dict:
-          print("Subscription successful. Subscription ID: ", response_dict['result'])
-
-       # Continuously read from the WebSocket
-       async for response in websocket:
-          
-           response_dict = json.loads(response)
-
-           if response_dict['params']['result']['value']['err'] == None :
-               signature = response_dict['params']['result']['value']['signature']
-
-               if signature not in seen_signatures:
-                  seen_signatures.add(signature)
-                  log_messages_set = set(response_dict['params']['result']['value']['logs'])
-
-                  search="initialize2"
-                  if any(search in message for message in log_messages_set):
-                      print(f"True, https://solscan.io/tx/{signature}")
-                      getTokens(signature)
-
-                 
-           else:
-               pass
+# Raydium Liquidity Pool V4
+RaydiumLPV4 = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
+URI = "https://api.mainnet-beta.solana.com"  # "https://api.devnet.solana.com" | "https://api.mainnet-beta.solana.com"
+WSS = "wss://api.mainnet-beta.solana.com"  # "wss://api.devnet.solana.com" | "wss://api.mainnet-beta.solana.com"
+solana_client = Client(URI)
+# Raydium function call name, look at raydium-amm/program/src/instruction.rs
+log_instruction = "initialize2"
 
 
 async def main():
-    await run()
+    """The client as an infinite asynchronous iterator:"""
+    async with connect(WSS) as websocket:
+        subscription_id = await subscribe_to_logs(websocket, Finalized)  # type: ignore
+        async for signature in process_messages(websocket, log_instruction):  # type: ignore
+            get_tokens(signature, RaydiumLPV4)
+            break 
+        await websocket.logs_unsubscribe(subscription_id)
 
-asyncio.run(main())
+
+async def subscribe_to_logs(websocket: SolanaWsClientProtocol,
+                            commitment: Commitment) -> int:
+    """Subscribed to logs, also posible use .send_data method"""
+    await websocket.logs_subscribe(commitment=commitment)
+    first_resp = await websocket.recv()
+    return get_subscription_id(first_resp)  # type: ignore
+
+
+def get_subscription_id(response: SubscriptionResult) -> int:
+    return response[0].result
+
+
+async def process_messages(websocket: SolanaWsClientProtocol,
+                           instruction: str) -> AsyncIterator[Signature]:
+    """Async generator, main websocket's loop"""
+    async for idx, msg in enumerate(websocket):
+        print(idx)
+        value = get_msg_value(msg)
+        if [log for log in value.logs if instruction in log]:
+            print(f"{value.signature=}")
+            pprint(value.logs)
+            yield value.signature
+
+
+def get_msg_value(msg: List[LogsNotification]) -> RpcLogsResponse:
+    return msg[0].result.value
+
+
+def get_tokens(signature: Signature, RaydiumLPV4: str) -> None:
+    """httpx.HTTPStatusError: Client error '429 Too Many Requests' 
+    for url 'https://api.mainnet-beta.solana.com'
+    For more information check: https://httpstatuses.com/429
+    """
+    transaction = solana_client.get_transaction( 
+        signature,
+        encoding="jsonParsed",
+        max_supported_transaction_version=0
+    )
+    # https://kevinheavey.github.io/solders/api_reference/instruction.html
+    instructions = get_instructions(transaction)
+    for instruction in instructions_with_program_id(instructions, RaydiumLPV4):
+        tokens = get_tokens_info(instruction)
+        print_table(tokens)
+
+
+def get_instructions(
+    transaction: GetTransactionResp
+) -> List[UiPartiallyDecodedInstruction | ParsedInstruction]:
+    instructions = transaction \
+                   .value \
+                   .transaction \
+                   .transaction \
+                   .message \
+                   .instructions
+    return instructions
+
+
+def instructions_with_program_id(
+    instructions: List[UiPartiallyDecodedInstruction | ParsedInstruction],
+    program_id: str
+) -> Iterator[UiPartiallyDecodedInstruction | ParsedInstruction]:
+    return (instruction for instruction in instructions
+            if instruction.program_id == Pubkey.from_string(program_id))
+
+
+def get_tokens_info(
+    instruction: UiPartiallyDecodedInstruction | ParsedInstruction
+) -> Tuple[Pubkey, Pubkey]:
+    accounts = instruction.accounts
+    Token0 = accounts[8]
+    Token1 = accounts[9]
+    return (Token0, Token1)
+
+
+def print_table(tokens: Tuple[Pubkey, Pubkey]) -> None:
+    data = [
+        {'Token_Index': 'Token0', 'Account Public Key': tokens[0]},  # Token0
+        {'Token_Index': 'Token1', 'Account Public Key': tokens[1]}   # Token1
+    ]
+    print("============NEW POOL DETECTED====================")
+    header = ["Token_Index", "Account Public Key"]
+    print("│".join(f" {col.ljust(15)} " for col in header))
+    print("|".rjust(18))
+    for row in data:
+        print("│".join(f" {str(row[col]).ljust(15)} " for col in header))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Your script was great point to start. I figured it out how  solana API works  thanks to you.

I did:
 - refactor code
 - break into functions
 - add type hinting
 - edit naming for some constants, variables and functions:

<details><summary>Diff</summary>
<p>

```diff
- wallet_address = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
+ RaydiumLPV4  = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
...
- search = "initialize2"
+ log_instruction = "initialize2"
...
- def getTokens(...)
+ def get_tokens_info(...)
```

</p>
</details> 

 - replaced standard websockets with SolanaWsClientProtocol from solana.rpc.websocket_api
```diff
- import websockets
+ from solana.rpc.websocket_api import connect
+ from solana.rpc.websocket_api import SolanaWsClientProtocol
```

 ```python

...
async with connect(WSS) as websocket:
        subscription_id = await subscribe_to_logs(
            websocket,
            RpcTransactionLogsFilterMentions(RaydiumLPV4),
            Finalized
        )
    ...
```
<details><summary>Diff</summary>
<p>
lines 41-79

```diff
- async def run():
-   uri = "wss://api.mainnet-beta.solana.com"
-   async with websockets.connect(uri) as websocket:
-       # Send subscription request
-       await websocket.send(json.dumps({
-           "jsonrpc": "2.0",
-           "id": 1,
-           "method": "logsSubscribe",
-           "params": [
-               {"mentions": [wallet_address]},
-               {"commitment": "finalized"}
-           ]
-       }))
-
-       first_resp = await websocket.recv()
-       response_dict = json.loads(first_resp)
-       if 'result' in response_dict:
-          print("Subscription successful. Subscription ID: ", response_dict['result'])
-
-       # Continuously read from the WebSocket
-       async for response in websocket:
-          
-           response_dict = json.loads(response)
-
-           if response_dict['params']['result']['value']['err'] == None :
-               signature = response_dict['params']['result']['value']['signature']
-
-               if signature not in seen_signatures:
-                  seen_signatures.add(signature)
-                  log_messages_set = set(response_dict['params']['result']['value']['logs'])
-
-                  search="initialize2"
-                  if any(search in message for message in log_messages_set):
-                      print(f"True, https://solscan.io/tx/{signature}")
-                      getTokens(signature)
-
-                 
-           else:
-               pass
```

lines 32-74
```diff
+ async def main():
+     """The client as an infinite asynchronous iterator:"""
+     async with connect(WSS) as websocket:
+         subscription_id = await subscribe_to_logs(
+             websocket,
+             RpcTransactionLogsFilterMentions(RaydiumLPV4),
+             Finalized
+         )  # type: ignore
+         async for signature in process_messages(websocket, log_instruction):  # type: ignore
+             get_tokens(signature, RaydiumLPV4)
+             break
+         await websocket.logs_unsubscribe(subscription_id)
+ 
+ 
+ async def subscribe_to_logs(websocket: SolanaWsClientProtocol, 
+                             mentions: RpcTransactionLogsFilterMentions,
+                             commitment: Commitment) -> int:
+     await websocket.logs_subscribe(
+         filter_=mentions,
+         commitment=commitment
+     )
+     first_resp = await websocket.recv()
+     return get_subscription_id(first_resp)  # type: ignore
+ 
+ 
+ def get_subscription_id(response: SubscriptionResult) -> int:
+     return response[0].result
+ 
+ 
+ async def process_messages(websocket: SolanaWsClientProtocol,
+                            instruction: str) -> AsyncIterator[Signature]:
+     """Async generator, main websocket's loop"""
+     async for idx, msg in enumerate(websocket):
+         value = get_msg_value(msg)
+         print(idx)
+         if [log for log in value.logs if instruction in log]:
+             print(f"{value.signature=}")
+             pprint(value.logs)
+             yield value.signature
+ 
+ 
+ def get_msg_value(msg: List[LogsNotification]) -> RpcLogsResponse:
+     return msg[0].result.value
```

</p>
</details> 

 - - it uses method `.logs_subscribe`, instead of `websocket.send(json.dumps(parametrs))`
```python
async def subscribe_to_logs(websocket: SolanaWsClientProtocol, 
                            mentions: RpcTransactionLogsFilterMentions,
                            commitment: Commitment) -> int:
    await websocket.logs_subscribe(
        filter_=mentions,
        commitment=commitment
    )
    first_resp = await websocket.recv()
    return get_subscription_id(first_resp) 
```
 - - log filtering happend inside `.process_messages`  in  list comprehension. 
 That function is generator function, indeed (yield instead return).
  its `yield` signature value if its logs align with required `log_instruction`.
```python
 async def process_messages(websocket: SolanaWsClientProtocol,
                            instruction: str) -> AsyncIterator[Signature]:
    """Async generator, main websocket's loop"""
    async for idx, msg in enumerate(websocket):
        value = get_msg_value(msg)
        print(idx)
        if [log for log in value.logs if instruction in log]:
            print(f"{value.signature=}")
            pprint(value.logs)
            yield value.signature
```
 - function get_tokens call inside for loop which iterate over `process_messages` generator,
 so its more obvious entries points and place to future modifications 
 - substitute pandas data frame to pure python string formatting in `print_table` function

There is still bunch place for optimization. 
But at this point its become more consistent due to using one lib for all purpose.
also its more easy for debugging and possible testing 

P.S.
script stops after finding first LP, remove `break` for infinite loop
```python
        async for signature in process_messages(websocket, log_instruction):  # type: ignore
            get_tokens(signature, RaydiumLPV4)
            break
```
