### PR TITLE
Workaround  for connection errors

### DIFF
--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -95,6 +95,7 @@ def get_tokens(signature: Signature, RaydiumLPV4: Pubkey) -> None:
     for instruction in instructions_with_program_id(instructions, RaydiumLPV4):
         tokens = get_tokens_info(instruction)
         print_table(tokens)
+        print(f"True, https://solscan.io/tx/{signature}")
 
 
 def get_instructions(
@@ -121,15 +122,17 @@ def get_tokens_info(
     instruction: UiPartiallyDecodedInstruction | ParsedInstruction
 ) -> Tuple[Pubkey, Pubkey]:
     accounts = instruction.accounts
+    Pair = accounts[4]
     Token0 = accounts[8]
     Token1 = accounts[9]
-    return (Token0, Token1)
+    return (Token0, Token1, Pair)
 
 
-def print_table(tokens: Tuple[Pubkey, Pubkey]) -> None:
+def print_table(tokens: Tuple[*Pubkey]) -> None:
     data = [
         {'Token_Index': 'Token0', 'Account Public Key': tokens[0]},  # Token0
-        {'Token_Index': 'Token1', 'Account Public Key': tokens[1]}   # Token1
+        {'Token_Index': 'Token1', 'Account Public Key': tokens[1]},  # Token1
+        {'Token_Index': 'LP Pair', 'Account Public Key': tokens[2]}  # LP Pair
     ]
     print("============NEW POOL DETECTED====================")
     header = ["Token_Index", "Account Public Key"]

--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -62,7 +62,7 @@ async def main():
                     continue
         except (ProtocolError, ConnectionClosedError) as err:
             # Restart socket connection if ProtocolError: invalid status code
-            logging.error(err)  # Logging
+            logging.exception(err)  # Logging
             print(f"Danger! Danger!", err)
             continue
         except KeyboardInterrupt:
@@ -121,15 +121,15 @@ def get_tokens(signature: Signature, RaydiumLPV4: Pubkey) -> None:
         encoding="jsonParsed",
         max_supported_transaction_version=0
     )
-    instructions = get_instructions(transaction)
-    filtred_instuctions = instructions_with_program_id(instructions, RaydiumLPV4)
     # Start logging to transactions.json
     with open("transactions.json", 'a', encoding='utf-8') as raw_transactions:
-        raw_transactions.write(f"signature: {signature}\n")
-        raw_transactions.write(transaction.to_json())        
-        raw_transactions.write("\n ########## \n")
-    logging.info(filtred_instuctions)
+    raw_transactions.write(f"signature: {signature}\n")
+    raw_transactions.write(transaction.to_json())        
+    raw_transactions.write("\n ########## \n")
     # End logging
+    instructions = get_instructions(transaction)
+    filtred_instuctions = instructions_with_program_id(instructions, RaydiumLPV4)
+    logging.info(filtred_instuctions)
     for instruction in filtred_instuctions:
         tokens = get_tokens_info(instruction)
         print_table(tokens)
@@ -158,7 +158,7 @@ def instructions_with_program_id(
 
 def get_tokens_info(
     instruction: UiPartiallyDecodedInstruction | ParsedInstruction
-) -> Tuple[Pubkey, Pubkey]:
+) -> Tuple[Pubkey, Pubkey, Pubkey]:
     accounts = instruction.accounts
     Pair = accounts[4]
     Token0 = accounts[8]
@@ -170,7 +170,7 @@ def get_tokens_info(
     return (Token0, Token1, Pair)
 
 
-def print_table(tokens: Tuple[*Pubkey]) -> None:
+def print_table(tokens: Tuple[Pubkey, Pubkey, Pubkey]) -> None:
     data = [
         {'Token_Index': 'Token0', 'Account Public Key': tokens[0]},  # Token0
         {'Token_Index': 'Token1', 'Account Public Key': tokens[1]},  # Token1

--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -39,8 +39,13 @@ async def main():
             Finalized
         )  # type: ignore
         async for signature in process_messages(websocket, log_instruction):  # type: ignore
-            get_tokens(signature, RaydiumLPV4)
-            #break
+            try:
+                get_tokens(signature, RaydiumLPV4)
+            except SolanaRpcException as err:
+                # Omitting httpx.HTTPStatusError: Client error '429 Too Many Requests'
+                # Sleep 5 sec, and try connect again
+                sleep(5)
+                continue
         await websocket.logs_unsubscribe(subscription_id)
 
 

--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -1,9 +1,7 @@
 "Detect  New Pools Created on Solana Raydium DEX"
 
-from pprint import pprint
 from time import sleep
 import logging
-
 
 import asyncio
 from typing import List, AsyncIterator, Tuple
@@ -35,8 +33,8 @@ log_instruction = "initialize2"
 
 # Init logging
 logging.basicConfig(filename='app.log', filemode='a', level=logging.DEBUG)
-
-
+# Writes responses from socket to messages.json
+# Writes responses from http req to  transactions.json
 
 async def main():
     """The client as an infinite asynchronous iterator:"""
@@ -100,6 +98,7 @@ async def process_messages(websocket: SolanaWsClientProtocol,
             # Start logging
             logging.info(value.signature)
             logging.info(log)
+            # Logging to messages.json
             with open("messages.json", 'a', encoding='utf-8') as raw_messages:  
                 raw_messages.write(f"signature: {value.signature} \n")
                 raw_messages.write(msg[0].to_json())
@@ -124,7 +123,7 @@ def get_tokens(signature: Signature, RaydiumLPV4: Pubkey) -> None:
     )
     instructions = get_instructions(transaction)
     filtred_instuctions = instructions_with_program_id(instructions, RaydiumLPV4)
-    # Start logging
+    # Start logging to transactions.json
     with open("transactions.json", 'a', encoding='utf-8') as raw_transactions:
         raw_transactions.write(f"signature: {signature}\n")
         raw_transactions.write(transaction.to_json())        

--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -1,22 +1,26 @@
 "Detect  New Pools Created on Solana Raydium DEX"
 
-#TODO Add Buys ,Sells price and liquidity pool tracking management
 from pprint import pprint
+from time import sleep
+import logging
+
 
 import asyncio
-from typing import Iterator, List, AsyncIterator, Tuple
+from typing import List, AsyncIterator, Tuple
 from asyncstdlib import enumerate
+
+from solders.pubkey import Pubkey
+from solders.rpc.config import RpcTransactionLogsFilterMentions
 
 from solana.rpc.websocket_api import connect
 from solana.rpc.commitment import Finalized
 from solana.rpc.api import Client
-
-from solders.pubkey import Pubkey
+from solana.exceptions import SolanaRpcException
+from websockets.exceptions import ConnectionClosedError, ProtocolError
 
 # Type hinting imports
 from solana.rpc.commitment import Commitment
 from solana.rpc.websocket_api import SolanaWsClientProtocol
-from solders.rpc.config import RpcTransactionLogsFilterMentions
 from solders.rpc.responses import RpcLogsResponse, SubscriptionResult, LogsNotification, GetTransactionResp
 from solders.signature import Signature
 from solders.transaction_status import UiPartiallyDecodedInstruction, ParsedInstruction
@@ -29,6 +33,10 @@ solana_client = Client(URI)
 # Raydium function call name, look at raydium-amm/program/src/instruction.rs
 log_instruction = "initialize2"
 
+# Init logging
+logging.basicConfig(filename='app.log', filemode='a', level=logging.DEBUG)
+
+
 
 async def main():
     """The client as an infinite asynchronous iterator:"""
@@ -39,16 +47,24 @@ async def main():
                 RpcTransactionLogsFilterMentions(RaydiumLPV4),
                 Finalized
             )
+            # Change level debugging to INFO
+            logging.getLogger().setLevel(logging.INFO)  # Logging
             async for i, signature in enumerate(process_messages(websocket, log_instruction)):  # type: ignore
+                logging.info(f"{i=}")  # Logging
                 try:
                     get_tokens(signature, RaydiumLPV4)
                 except SolanaRpcException as err:
                     # Omitting httpx.HTTPStatusError: Client error '429 Too Many Requests'
                     # Sleep 5 sec, and try connect again
+                    # Start logging
+                    logging.exception(err)
+                    logging.info("sleep for 5 seconds and try again")
+                    # End logging
                     sleep(5)
                     continue
         except (ProtocolError, ConnectionClosedError) as err:
             # Restart socket connection if ProtocolError: invalid status code
+            logging.error(err)  # Logging
             print(f"Danger! Danger!", err)
             continue
         except KeyboardInterrupt:
@@ -76,10 +92,19 @@ async def process_messages(websocket: SolanaWsClientProtocol,
     """Async generator, main websocket's loop"""
     async for idx, msg in enumerate(websocket):
         value = get_msg_value(msg)
-        #print(idx)
-        if [log for log in value.logs if instruction in log]:
-            print(f"{value.signature=}")
-            #pprint(value.logs)
+        if not idx % 100:
+            print(f"{idx=}")
+        for log in value.logs:
+            if instruction not in log:
+                continue
+            # Start logging
+            logging.info(value.signature)
+            logging.info(log)
+            with open("messages.json", 'a', encoding='utf-8') as raw_messages:  
+                raw_messages.write(f"signature: {value.signature} \n")
+                raw_messages.write(msg[0].to_json())
+                raw_messages.write("\n ########## \n")
+            # End logging
             yield value.signature
 
 
@@ -97,9 +122,16 @@ def get_tokens(signature: Signature, RaydiumLPV4: Pubkey) -> None:
         encoding="jsonParsed",
         max_supported_transaction_version=0
     )
-    # https://kevinheavey.github.io/solders/api_reference/instruction.html
     instructions = get_instructions(transaction)
-    for instruction in instructions_with_program_id(instructions, RaydiumLPV4):
+    filtred_instuctions = instructions_with_program_id(instructions, RaydiumLPV4)
+    # Start logging
+    with open("transactions.json", 'a', encoding='utf-8') as raw_transactions:
+        raw_transactions.write(f"signature: {signature}\n")
+        raw_transactions.write(transaction.to_json())        
+        raw_transactions.write("\n ########## \n")
+    logging.info(filtred_instuctions)
+    # End logging
+    for instruction in filtred_instuctions:
         tokens = get_tokens_info(instruction)
         print_table(tokens)
         print(f"True, https://solscan.io/tx/{signature}")
@@ -132,6 +164,10 @@ def get_tokens_info(
     Pair = accounts[4]
     Token0 = accounts[8]
     Token1 = accounts[9]
+    # Start logging
+    logging.info("find LP !!!")
+    logging.info(f"\n Token0: {Token0}, \n Token1: {Token1}, \n Pair: {Pair}")
+    # End logging
     return (Token0, Token1, Pair)
 
 

--- a/Solana/NewlyCreatedPairs.py
+++ b/Solana/NewlyCreatedPairs.py
@@ -123,9 +123,9 @@ def get_tokens(signature: Signature, RaydiumLPV4: Pubkey) -> None:
     )
     # Start logging to transactions.json
     with open("transactions.json", 'a', encoding='utf-8') as raw_transactions:
-    raw_transactions.write(f"signature: {signature}\n")
-    raw_transactions.write(transaction.to_json())        
-    raw_transactions.write("\n ########## \n")
+        raw_transactions.write(f"signature: {signature}\n")
+        raw_transactions.write(transaction.to_json())        
+        raw_transactions.write("\n ########## \n")
     # End logging
     instructions = get_instructions(transaction)
     filtred_instuctions = instructions_with_program_id(instructions, RaydiumLPV4)


### PR DESCRIPTION
Hi, check some updates.
- fix the previous problem with HTTPStatusError
- New  one with WebSockets ProtocolError and ConnectionClosedError
- Add logging and writing  to file responses from sockets and API

**HTTPStatusError**
Make a workaround for the RPC API client. Catch  SolandaRPCexception for any case errors, wait some time, and try again

```python
def main():
...
try:
    get_tokens(signature, RaydiumLPV4)
except SolanaRpcException as err:
    # Omitting httpx.HTTPStatusError: Client error '429 Too Many Requests'
    # Sleep 5 sec, and try connect again
    sleep(5)
    continue
...
```

**ProtocolError and ConnectionClosedError**
Also, I caught some spontaneous errors with WebSockets, you could check Traceback.
Unfortunately, my knowledge isn't enough to find the root cause of these errors.
I changed context manager to for loop, so I use `websocket_api.connect` as an infinite asynchronous iterator to reconnect automatically on errors

```python
def main():
...
try:
    ...
    async for i, signature in enumerate(process_messages(websocket, log_instruction)):
        try:
            get_tokens(signature, RaydiumLPV4)
        except SolanaRpcException as err:
            sleep(5)
            continue
except (ProtocolError, ConnectionClosedError) as err:
    # Restart socket connection if error happend
    continue
...
```

<details><summary>Traceback</summary>
<p>

```
Traceback (most recent call last):
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 959, in transfer_data
    message = await self.read_message()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 1029, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 1110, in read_data_frame
    self.close_rcvd = Close.parse(frame.data)
                      ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/frames.py", line 425, in parse
    close.check()
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/frames.py", line 449, in check
    raise exceptions.ProtocolError("invalid status code")
websockets.exceptions.ProtocolError: invalid status code

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/artemii/code/solana/newlpcreated.py", line 193, in <module>
    asyncio.run(main())
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/artemii/code/solana/newlpcreated.py", line 70, in main
    await websocket.logs_unsubscribe(subscription_id)
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/solana/rpc/websocket_api.py", line 176, in logs_unsubscribe
    await self.send_data(req)
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/solana/rpc/websocket_api.py", line 98, in send_data
    await super().send(to_send)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 635, in send
    await self.ensure_open()
  File "/home/artemii/code/solana/env/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 935, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: sent 1002 (protocol error); no close frame received

```

</p>
</details> 

**Logging**
Add logging. It the first time I have used it, thus it look creepy.
Initialize it with logging level `DEBUG`, but after calling await `subscribe_to_logs()`  i switch  level to `INFO`, intend is my desire to check parameters of connections.
```python
...
logging.basicConfig(filename='app.log', filemode='a', level=logging.DEBUG)
....
logging.getLogger().setLevel(logging.INFO)  # Logging
...
 ```

then i logging some truncated information 
```python
...
logging.info(value.signature)
logging.info(log)
...
logging.info(filtred_instuctions)
...
logging.info(f"\n Token0: {Token0}, \n Token1: {Token1}, \n Pair: {Pair}")
...
```

Also I start write complete responses in json into files.

```python
...
async def process_messages():
...
with open("messages.json", 'a', encoding='utf-8') as raw_messages:  
    raw_messages.write(f"signature: {value.signature} \n")
    raw_messages.write(msg[0].to_json())
    raw_messages.write("\n ########## \n")
...
```
```python
...
def get_tokens():
...
with open("transactions.json", 'a', encoding='utf-8') as raw_transactions:
    raw_transactions.write(f"signature: {signature}\n")
    raw_transactions.write(transaction.to_json())        
    raw_transactions.write("\n ########## \n")
...

```



